### PR TITLE
Separate ground truth coords edition from hourglass

### DIFF
--- a/src/dlh/utils/test_utils.py
+++ b/src/dlh/utils/test_utils.py
@@ -383,7 +383,7 @@ def edit_subject_lines_txt_file(coords, txt_lines, subject_name, contrast, metho
     
     :param coords: 
         - numpy array of the 2D coordinates of discs plus discs num --> [[x1, y1, disc1], [x2, y2, disc2], ... [xN, yN, discN]]
-        - if coords == 'Fail' --> method enable to perform on this subject
+        - if coords == np.array([]) # Fail --> method enable to perform on this subject
     :param txt_lines: list of the txt file lines
     :param subject_name: name of the subject in the text file
     :param contrast: contrast of the image
@@ -401,7 +401,8 @@ def edit_subject_lines_txt_file(coords, txt_lines, subject_name, contrast, metho
     else:
         end_of_line = ''
         
-    if coords == 'Fail':
+    if coords.shape[0] == 0: # Fail
+        print(f'{method_name} fails with subject {subject_name}')
         for i, _ in enumerate(range(min_ref_disc, max_ref_disc+1)):
             txt_lines[start_index + i][method_idx] = 'Fail' + end_of_line
     else:
@@ -420,7 +421,7 @@ def edit_subject_lines_txt_file(coords, txt_lines, subject_name, contrast, metho
                     new_line = [subject_name, contrast, str(disc_num), 'None', 'None', 'None', 'None\n']
                     disc_shift = disc_num - max_ref_disc # Check if discs are missing between in the text file
                     if disc_shift != 1:
-                        print(f'Adding intermediate {disc_shift-1} discs to txt file')
+                        print(f'Adding {disc_shift-1} intermediate discs to txt file')
                         for shift in range(disc_shift-1):
                             last_index += 1
                             intermediate_line = new_line[:]

--- a/test/test_hourglass_network.py
+++ b/test/test_hourglass_network.py
@@ -75,7 +75,6 @@ def test_hourglass(args):
         subject_name = subject_name[0]
         
         prediction, pred_discs_coords = extract_skeleton(inputs, output, targets, norm_mean_skeleton, ndiscs, Flag_save=True)
-        gt_coord = np.array(torch.tensor(gt_coord).tolist())
         
         # Convert pred_discs_coords to original image size
         pred_shape = prediction[0,0].shape 
@@ -85,18 +84,12 @@ def test_hourglass(args):
         # Project coordinate onto the spinal cord centerline
         seg_path = os.path.join(origin_data, subject_name, f'{subject_name}_{contrast[0]}_seg.nii.gz' )
         pred = project_on_spinal_cord(coords=pred, seg_path=seg_path, disc_num=True, proj_2d=True)
-        gt_coord = project_on_spinal_cord(coords=gt_coord, seg_path=seg_path, disc_num=True, proj_2d=False)
-        
-        # Remove thinkness coordinate
-        gt_coord = gt_coord[:, 1:]
         
         # Swap axis prediction and ground truth
         pred = swap_y_origin(coords=pred, img_shape=original_shape, y_pos=0).astype(int)  # Move y origin to the bottom of the image like Niftii convention
-        gt_coord = swap_y_origin(coords=gt_coord, img_shape=original_shape, y_pos=0).astype(int)  # Move y origin to the bottom of the image like Niftii convention
         
         # Edit coordinates in txt file
         # line = subject_name contrast disc_num gt_coords sct_discs_coords hourglass_coords spinenet_coords
-        split_lines = edit_subject_lines_txt_file(coords=gt_coord, txt_lines=split_lines, subject_name=subject_name, contrast=contrast[0], method_name='gt_coords')
         split_lines = edit_subject_lines_txt_file(coords=pred, txt_lines=split_lines, subject_name=subject_name, contrast=contrast[0], method_name='hourglass_coords')
                 
     for num in range(len(split_lines)):

--- a/test/test_sct_label_vertebrae.py
+++ b/test/test_sct_label_vertebrae.py
@@ -36,7 +36,7 @@ def test_sct_label_vertebrae(args):
                                         '-o', seg_path])
                 if status != 0:
                     print('Fail segmentation')
-                    discs_coords = 'Fail'
+                    discs_coords = np.array([]) # Fail
             
             disc_file_path = file_path.replace('.nii.gz', '_seg_labeled_discs.nii.gz')  # path to the file with disc labels
             if os.path.exists(disc_file_path):
@@ -57,7 +57,7 @@ def test_sct_label_vertebrae(args):
                 else:
                     print('Exit value 1')
                     print('Fail sct_label_vertebrae')
-                    discs_coords = 'Fail'
+                    discs_coords = np.array([]) # Fail
             
             subject_name = dir_name
             # Edit coordinates in txt file

--- a/test/test_spinenet_network.py
+++ b/test/test_spinenet_network.py
@@ -47,10 +47,8 @@ def test_spinenet(args, test_mode=False):
             # detect and identify vertebrae in scan. Note that pixel spacing information is required 
             # so SpineNet knows what size to split patches into.
             try:
-                vert_dicts_niftii = spnt.detect_vb(img, 1/px)
-                print('1/px =', 1/px)
+                vert_dicts_niftii = spnt.detect_vb(img, px)
             except RuntimeError:
-                print(f'Spinenet Fail detection on subject {subject_name}')
                 vert_dicts_niftii = 'Fail'
 
             if vert_dicts_niftii != 'Fail':
@@ -91,7 +89,7 @@ def test_spinenet(args, test_mode=False):
                 # Move y origin to the bottom of the image like Niftii convention
                 coords = swap_y_origin(coords=coords, img_shape=img[:,:,0].shape, y_pos=0).astype(int)
             else:
-                coords = 'Fail'
+                coords = np.array([]) # Fail
 
             if not test_mode: 
                 # Write coordinates in txt file


### PR DESCRIPTION
## Description
During testing, ground truth coordinates are now added to the text file separately.

## Related issue
https://github.com/spinalcordtoolbox/disc-labeling-hourglass/issues/13